### PR TITLE
Add support for bulk track/engage APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,34 @@ Mixpanel.track("login", distinct_id: 123)
 Mixpanel.track("visited TOS")
 ```
 
+Or with bulk sending:
+
+```elixir
+Mixpanel.track([
+  %{event: "login", properties: %{distinct_id: "13793"}},
+  %{event: "logout", properties: %{distinct_id: "13793"}}
+  ])
+```
+
+See the [Mixpanel HTTP API documentation](https://mixpanel.com/help/reference/http#tracking-events) for details.
+
+
+5) Track users with `Mixpanel.engage`:
+
+```elixir
+Mixpanel.engage(%{"$distinct_id" => "123", "$set" => %{"name" => "John Smith"}})
+```
+
+Or in bulk:
+
+```elixir
+Mixpanel.engage([
+  %{"$distinct_id" => "123", "$set" => %{"name" => "John Smith"}},
+  %{"$distinct_id" => "345", "$set" => %{"address" => "456 Central Ave"}}
+  ])
+```
+
+See the [Mixpanel HTTP API documentation](https://mixpanel.com/help/reference/http#people-analytics-updates) for details.
+
 ## License
 MIT
-

--- a/lib/mixpanel.ex
+++ b/lib/mixpanel.ex
@@ -18,23 +18,23 @@ defmodule Mixpanel do
 
   def track(event, properties, timestamp \\ nil) do
     properties = Mixpanel.Util.add_timestamp(properties, timestamp)
-    Mixpanel.Client.track(event, properties)
-    :ok
+    track([%{event: event, properties: properties}])
   end
 
-  def track(event) when is_binary(event), do: track(event, [])
+  def track(event) when is_binary(event) do
+    track(event, [])
+  end
+
   def track(events) when is_list(events) do
     Mixpanel.Client.track(events)
-    :ok
   end
 
   def engage(event) when is_map(event) do
-    Mixpanel.Client.engage(event)
-    :ok
+    engage([event])
   end
+
   def engage(events) when is_list(events) do
     Mixpanel.Client.engage(events)
-    :ok
   end
 
   defmodule Util do

--- a/lib/mixpanel.ex
+++ b/lib/mixpanel.ex
@@ -16,9 +16,24 @@ defmodule Mixpanel do
     Supervisor.start_link(children, opts)
   end
 
-  def track(event, properties \\ [], timestamp \\ nil) do
+  def track(event, properties, timestamp \\ nil) do
     properties = Mixpanel.Util.add_timestamp(properties, timestamp)
     Mixpanel.Client.track(event, properties)
+    :ok
+  end
+
+  def track(event) when is_binary(event), do: track(event, [])
+  def track(events) when is_list(events) do
+    Mixpanel.Client.track(events)
+    :ok
+  end
+
+  def engage(event) when is_map(event) do
+    Mixpanel.Client.engage(event)
+    :ok
+  end
+  def engage(events) when is_list(events) do
+    Mixpanel.Client.engage(events)
     :ok
   end
 
@@ -33,4 +48,3 @@ defmodule Mixpanel do
   end
 
 end
-

--- a/lib/mixpanel/client.ex
+++ b/lib/mixpanel/client.ex
@@ -1,7 +1,8 @@
 require Logger
 
 defmodule Mixpanel.Client do
-  @events_endpoint 'https://api.mixpanel.com/track'
+  @track_endpoint 'https://api.mixpanel.com/track'
+  @engage_endpoint 'https://api.mixpanel.com/engage'
   @success_response_body '1'
 
   use GenServer
@@ -18,19 +19,53 @@ defmodule Mixpanel.Client do
     GenServer.cast(:mixpanel_client, {:track, event, properties})
   end
 
+  def track(events) when is_list(events) do
+    GenServer.cast(:mixpanel_client, {:track, events})
+  end
+
+  def engage(event) when is_map(event) do
+    GenServer.cast(:mixpanel_client, {:engage, event})
+  end
+
+  def engage(events) when is_list(events) do
+    GenServer.cast(:mixpanel_client, {:engage, events})
+  end
+
   def handle_cast({:track, event, properties}, state)  do
     properties = Dict.put(properties, :token, state.token)
-    {:ok, json} = JSX.encode([event: event, properties: properties])
-    body = String.to_char_list("data=#{ :base64.encode(json) }")
-
-    request = {@events_endpoint, _headers = [], _content_type = 'text/plain', body}
-    result = :httpc.request(:post, request, _http_opts=[], _opts=[], state.connection)
-    case result do
-      {:ok, {_, _, @success_response_body}} -> :ok
-      _ -> Logger.warn("Problem tracking mixpanel event: " <> inspect(result))
-    end
-
+    {:ok, json} = JSX.encode(event: event, properties: properties)
+    bulk_post(json, state.connection, @track_endpoint)
     {:noreply, state}
   end
-end
 
+  def handle_cast({:track, events}, state) when is_list(events) do
+    events = Enum.map(events, &put_in(&1, [:properties, :token], state.token))
+    {:ok, json} = JSX.encode(events)
+    bulk_post(json, state.connection, @track_endpoint)
+    {:noreply, state}
+  end
+
+  def handle_cast({:engage, event}, state) when is_map(event) do
+    events = [Map.put(event, :"$token", state.token)]
+    {:ok, json} = JSX.encode(events)
+    bulk_post(json, state.connection, @engage_endpoint)
+    {:noreply, state}
+  end
+
+  def handle_cast({:engage, events}, state) when is_list(events) do
+    events = Enum.map(events, &Map.put(&1, :"$token", state.token))
+    {:ok, json} = JSX.encode(events)
+    bulk_post(json, state.connection, @engage_endpoint)
+    {:noreply, state}
+  end
+
+  defp bulk_post(json, connection, endpoint) do
+    body = String.to_char_list("data=#{ :base64.encode(json) }")
+    request = {endpoint, _headers = [], _content_type = 'text/plain', body}
+    result = :httpc.request(:post, request, _http_opts=[], _opts=[], connection)
+    case result do
+      {:ok, {_, _, @success_response_body}} -> :ok
+      _ -> Logger.warn("Problem with mixpanel event: " <> inspect(result))
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,9 @@ defmodule Mixpanel.Mixfile do
        licenses: ["MIT"],
        links: %{"Github" => "https://github.com/michihuber/mixpanel_ex"},
      ],
+     preferred_cli_env: [
+        vcr: :test, "vcr.delete": :test, "vcr.check": :test, "vcr.show": :test
+      ],
     ]
   end
 
@@ -23,7 +26,7 @@ defmodule Mixpanel.Mixfile do
   end
 
   defp deps do
-    [{:exjsx, "~> 3.1.0"}]
+    [{:exjsx, "~> 3.1"},
+     {:exvcr, "~> 0.7", only: :test}]
   end
 end
-

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,5 @@
-%{"exjsx": {:hex, :exjsx, "3.1.0", "d419162cb2d5be80070835c2c2b8c78c8c45907706c991d23f3750dae506d1e9", [:mix], [{:jsx, "~> 2.4.0", [hex: :jsx, optional: false]}]},
-  "jsx": {:hex, :jsx, "2.4.0", "fb83830ac15e981b6ce310b645324ceecd01b1e0847d23921c33df829de5d2db", [:mix], []}}
+%{"exactor": {:hex, :exactor, "2.2.2", "90b27d72c05614801a60f8400afd4e4346dfc33ea9beffe3b98a794891d2ff96", [:mix], []},
+  "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
+  "exvcr": {:hex, :exvcr, "0.8.3", "432557201917f54bc6d78e9214f9d7c074aa4d67c5e7b5f51a1d391aad7fa31b", [:mix], [{:exactor, "~> 2.2", [hex: :exactor, optional: false]}, {:exjsx, "~> 3.2", [hex: :exjsx, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: true]}, {:httpotion, "~> 3.0", [hex: :httpotion, optional: true]}, {:ibrowse, "~> 4.2.2", [hex: :ibrowse, optional: true]}, {:meck, "~> 0.8.3", [hex: :meck, optional: false]}]},
+  "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"exjsx": {:hex, :exjsx, "3.1.0"},
-  "jsx": {:hex, :jsx, "2.4.0"}}
+%{"exjsx": {:hex, :exjsx, "3.1.0", "d419162cb2d5be80070835c2c2b8c78c8c45907706c991d23f3750dae506d1e9", [:mix], [{:jsx, "~> 2.4.0", [hex: :jsx, optional: false]}]},
+  "jsx": {:hex, :jsx, "2.4.0", "fb83830ac15e981b6ce310b645324ceecd01b1e0847d23921c33df829de5d2db", [:mix], []}}

--- a/test/mixpanel_test.exs
+++ b/test/mixpanel_test.exs
@@ -1,0 +1,47 @@
+defmodule MixpanelTest do
+
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Httpc
+
+  setup_all do
+    :inets.start
+    :ok
+  end
+
+  test "track an event with no additional properties" do
+    use_cassette "mixpanel_track_simple_event" do
+      :ok = Mixpanel.track("visited TOS")
+    end
+  end
+
+  test "track an event with additional properties" do
+    use_cassette "mixpanel_track_event_with_properties" do
+      :ok = Mixpanel.track("login", distinct_id: 12345)
+    end
+  end
+
+  test "Bulk track events" do
+    use_cassette "mixpanel_bulk_track_events" do
+      :ok = Mixpanel.track([
+          %{event: "login", properties: %{unique_id: 12345}},
+          %{event: "logout", properties: %{unique_id: 12345}}
+        ])
+    end
+  end
+
+  test "Single user profile update" do
+    use_cassette "mixpanel_engage_event" do
+      :ok = Mixpanel.engage(%{"$distinct_id": "123", "$set": %{name: "John Smith"}})
+    end
+  end
+
+  test "Bulk user profile update" do
+    use_cassette "mixpanel_bulk_engage_events" do
+      :ok = Mixpanel.engage([
+          %{"$distinct_id": "123", "$set": %{name: "John Smith"}},
+          %{"$distinct_id": "345", "$set": %{address: "456 Central Ave"}}
+        ])
+    end
+  end
+
+end


### PR DESCRIPTION
- `Mixpanel.engage` function added to update user profile
- `Mixpanel.track` and `Mixpanel.engage` will both support a list of maps
- When given a list, these functions expect the maps to conform to the structure defined by
  the mixpanel HTTP api documentation (linked from README)
